### PR TITLE
bump development dependencies

### DIFF
--- a/castle-middleware.gemspec
+++ b/castle-middleware.gemspec
@@ -32,10 +32,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'coveralls_reborn'
 
   spec.add_dependency 'castle-rb', '~> 2.3.2'
 end


### PR DESCRIPTION
also switch to `coveralls_reborn` for latest dependencies